### PR TITLE
Add run files for high resolution runs, fixed date

### DIFF
--- a/Run_AtlantisCmd.sh
+++ b/Run_AtlantisCmd.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-atlantis run ./atlantis.yaml /ocean/rlovindeer/MOAD/analysis-raisha/SSmodel_outputs/5b_2020spill_35yrun_07
+atlantis run ./atlantis.yaml /ocean/rlovindeer/MOAD/analysis-raisha/SSmodel_outputs/TurnPoint_2020_control

--- a/SS_forcing_contam_2020spill.prm
+++ b/SS_forcing_contam_2020spill.prm
@@ -101,7 +101,7 @@ tracerNames 4
 Naphthalene Phenanthrene Pyrene Benzo
 
 # Now the actual files. Can have more than one tracer in a file
-Naphthalene_nFiles 30
+Naphthalene_nFiles 29
 Naphthalene_File0.name contaminants01.nc
 Naphthalene_File1.name contaminants01.nc
 Naphthalene_File2.name contaminants01.nc
@@ -129,9 +129,8 @@ Naphthalene_File23.name contaminants01.nc
 Naphthalene_File24.name contaminants01.nc
 Naphthalene_File25.name contaminants01.nc
 Naphthalene_File26.name contaminants01.nc
-Naphthalene_File27.name contaminants01.nc
-Naphthalene_File28.name contaminants02.nc
-Naphthalene_File29.name contaminants03.nc
+Naphthalene_File27.name contaminants02.nc
+Naphthalene_File28.name contaminants03.nc
 Naphthalene_rewind 0
 Naphthalene_File0.use_resets 0
 Naphthalene_File1.use_resets 0
@@ -160,12 +159,11 @@ Naphthalene_File23.use_resets 0
 Naphthalene_File24.use_resets 0
 Naphthalene_File25.use_resets 0
 Naphthalene_File26.use_resets 0
-Naphthalene_File27.use_resets 0
-Naphthalene_File28.use_resets 1
-Naphthalene_File29.use_resets 0
+Naphthalene_File27.use_resets 1
+Naphthalene_File28.use_resets 0
 Naphthalene_ResetTol 0.1
 
-Phenanthrene_nFiles 30
+Phenanthrene_nFiles 29
 Phenanthrene_File0.name contaminants01.nc
 Phenanthrene_File1.name contaminants01.nc
 Phenanthrene_File2.name contaminants01.nc
@@ -193,9 +191,8 @@ Phenanthrene_File23.name contaminants01.nc
 Phenanthrene_File24.name contaminants01.nc
 Phenanthrene_File25.name contaminants01.nc
 Phenanthrene_File26.name contaminants01.nc
-Phenanthrene_File27.name contaminants01.nc
-Phenanthrene_File28.name contaminants02.nc
-Phenanthrene_File29.name contaminants03.nc
+Phenanthrene_File27.name contaminants02.nc
+Phenanthrene_File28.name contaminants03.nc
 Phenanthrene_rewind 0
 Phenanthrene_File0.use_resets 0
 Phenanthrene_File1.use_resets 0
@@ -224,12 +221,11 @@ Phenanthrene_File23.use_resets 0
 Phenanthrene_File24.use_resets 0
 Phenanthrene_File25.use_resets 0
 Phenanthrene_File26.use_resets 0
-Phenanthrene_File27.use_resets 0
-Phenanthrene_File28.use_resets 1
-Phenanthrene_File29.use_resets 0
+Phenanthrene_File27.use_resets 1
+Phenanthrene_File28.use_resets 0
 Phenanthrene_ResetTol 0.1
 
-Pyrene_nFiles 30
+Pyrene_nFiles 29
 Pyrene_File0.name contaminants01.nc
 Pyrene_File1.name contaminants01.nc
 Pyrene_File2.name contaminants01.nc
@@ -257,9 +253,8 @@ Pyrene_File23.name contaminants01.nc
 Pyrene_File24.name contaminants01.nc
 Pyrene_File25.name contaminants01.nc
 Pyrene_File26.name contaminants01.nc
-Pyrene_File27.name contaminants01.nc
-Pyrene_File28.name contaminants02.nc
-Pyrene_File29.name contaminants03.nc
+Pyrene_File27.name contaminants02.nc
+Pyrene_File28.name contaminants03.nc
 Pyrene_rewind 0
 Pyrene_File0.use_resets 0
 Pyrene_File1.use_resets 0
@@ -288,12 +283,11 @@ Pyrene_File23.use_resets 0
 Pyrene_File24.use_resets 0
 Pyrene_File25.use_resets 0
 Pyrene_File26.use_resets 0
-Pyrene_File27.use_resets 0
-Pyrene_File28.use_resets 1
-Pyrene_File29.use_resets 0
+Pyrene_File27.use_resets 1
+Pyrene_File28.use_resets 0
 Pyrene_ResetTol 0.1
 
-Benzo_nFiles 30
+Benzo_nFiles 29
 Benzo_File0.name contaminants01.nc
 Benzo_File1.name contaminants01.nc
 Benzo_File2.name contaminants01.nc
@@ -321,9 +315,8 @@ Benzo_File23.name contaminants01.nc
 Benzo_File24.name contaminants01.nc
 Benzo_File25.name contaminants01.nc
 Benzo_File26.name contaminants01.nc
-Benzo_File27.name contaminants01.nc
-Benzo_File28.name contaminants02.nc
-Benzo_File29.name contaminants03.nc
+Benzo_File27.name contaminants02.nc
+Benzo_File28.name contaminants03.nc
 Benzo_rewind 0
 Benzo_File0.use_resets 0
 Benzo_File1.use_resets 0
@@ -352,9 +345,8 @@ Benzo_File23.use_resets 0
 Benzo_File24.use_resets 0
 Benzo_File25.use_resets 0
 Benzo_File26.use_resets 0
-Benzo_File27.use_resets 0
-Benzo_File28.use_resets 1
-Benzo_File29.use_resets 0
+Benzo_File27.use_resets 1
+Benzo_File28.use_resets 0
 Benzo_ResetTol 0.1
 
 # Light and noise pollutants

--- a/SS_run_contam.prm
+++ b/SS_run_contam.prm
@@ -1,6 +1,6 @@
 # March - August 2019, Heidi Pethybridge
 # Updated July 2020, Javier Porobic
-# Updated May 2022, Beth Fulton & Raisha Lovindeer
+# Updated Jan 2023, Beth Fulton & Raisha Lovindeer
 # Salish Sea Atlantis model run file
 #############################################
 # Run parameters
@@ -29,6 +29,7 @@ flag_old_embryo_init        0
 flag_replicate_old_calendar 0
 external_populations        0
 flag_multiyr_migs           1
+flag_mig_in_bioindx         1
 store_aggregate_yoy         1
 store_mig_array             1
 
@@ -44,7 +45,7 @@ checkNH       0        # Give detailed logged output for NH in checkbox
 checkDL       0        # Give detailed logged output for DL in checkbox
 checkDR       0        # Give detailed logged output for DR in checkbox
 checkbiom     0        # Give detailed logged output for biomasses in checkbox
-which_check   110        # ID number of group to track (if don't want to track anything set to 80 (for other groups see list below)
+which_check   0        # ID number of group to track (if don't want to track anything set to 80 (for other groups see list below)
 habitat_check 0
 which_fleet   33       # ID number of fleet to track (if don't want to track anything set to 33 (for other fleets see list below)
 move_check    67       # ID number of group where tracking movements  (if don't want to track anything set it to 67, for other groups see list below)

--- a/SS_run_control.prm
+++ b/SS_run_control.prm
@@ -1,6 +1,6 @@
 # March - August 2019, Heidi Pethybridge
 # Updated July 2020, Javier Porobic
-# Updated June 2022, Beth Fulton
+# Updated Jan 2023, Beth Fulton & Raisha Lovindeer
 # Salish Sea Atlantis model run file
 #############################################
 # Run parameters
@@ -29,6 +29,7 @@ flag_old_embryo_init        0
 flag_replicate_old_calendar 0
 external_populations        0
 flag_multiyr_migs           1
+flag_mig_in_bioindx         1
 store_aggregate_yoy         1
 store_mig_array             1
 
@@ -44,7 +45,7 @@ checkNH       0        # Give detailed logged output for NH in checkbox
 checkDL       0        # Give detailed logged output for DL in checkbox
 checkDR       0        # Give detailed logged output for DR in checkbox
 checkbiom     0        # Give detailed logged output for biomasses in checkbox
-which_check   110        # ID number of group to track (if don't want to track anything set to 80 (for other groups see list below)
+which_check   0        # ID number of group to track (if don't want to track anything set to 80 (for other groups see list below)
 habitat_check 0
 which_fleet   33       # ID number of fleet to track (if don't want to track anything set to 33 (for other fleets see list below)
 move_check    67       # ID number of group where tracking movements  (if don't want to track anything set it to 67, for other groups see list below)
@@ -55,7 +56,7 @@ debug         0        # 0=debuging off, 1=debug fishing, 2=debug discards, 3=de
                        # 12=debug migration, 13=debug movement, 14=debug stocks,
                        # 15=debug biomass calcs, 16=debug feeding, 17=debug everything
 
-flag_age_output  1     # 1 = age structured overall biomass output desired, 0 = off     **/spreadsheets/d/1z4CkgIRV6rxS4AVmXgtsu-pOBb0rllxs/edit
+flag_age_output  1     # 1 = age structured overall biomass output desired, 0 = off     **
 
 debug_it      0
 flagIsEstuary 0

--- a/ShipScrubber/Run_scrubber.sh
+++ b/ShipScrubber/Run_scrubber.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-atlantis run ./atlantis_scrubber.yaml /ocean/rlovindeer/MOAD/analysis-raisha/SSmodel_outputs/Scrubber_discharge_2019_highres_mort
+atlantis run ./atlantis_scrubber.yaml /ocean/rlovindeer/MOAD/analysis-raisha/SSmodel_outputs/Scrubber_discharge_2019_highres_mort2

--- a/ShipScrubber/Run_scrubber.sh
+++ b/ShipScrubber/Run_scrubber.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-atlantis run ./atlantis_scrubber.yaml /ocean/rlovindeer/MOAD/analysis-raisha/SSmodel_outputs/Scrubber_discharge_2019-2029_02
+atlantis run ./atlantis_scrubber.yaml /ocean/rlovindeer/MOAD/analysis-raisha/SSmodel_outputs/Scrubber_discharge_2019_highres_mort

--- a/ShipScrubber/SS_forcing2019.prm
+++ b/ShipScrubber/SS_forcing2019.prm
@@ -102,7 +102,7 @@ Phenanthrene
 
 # Now the actual files. Can have more than one tracer in a file
 
-Phenanthrene_nFiles 28
+Phenanthrene_nFiles 27
 Phenanthrene_File0.name contaminants01.nc
 Phenanthrene_File1.name contaminants01.nc
 Phenanthrene_File2.name contaminants01.nc
@@ -129,8 +129,7 @@ Phenanthrene_File22.name contaminants01.nc
 Phenanthrene_File23.name contaminants01.nc
 Phenanthrene_File24.name contaminants01.nc
 Phenanthrene_File25.name contaminants01.nc
-Phenanthrene_File26.name contaminants01.nc
-Phenanthrene_File27.name contaminants02.nc
+Phenanthrene_File26.name contaminants02.nc
 Phenanthrene_rewind 0
 Phenanthrene_File0.use_resets 0
 Phenanthrene_File1.use_resets 0
@@ -159,7 +158,6 @@ Phenanthrene_File23.use_resets 0
 Phenanthrene_File24.use_resets 0
 Phenanthrene_File25.use_resets 0
 Phenanthrene_File26.use_resets 0
-Phenanthrene_File27.use_resets 0
 
 Phenanthrene_ResetTol 0.1
 

--- a/ShipScrubber/SS_run.prm
+++ b/ShipScrubber/SS_run.prm
@@ -65,12 +65,12 @@ tburnday      0
 
 title      SalishSea model run
 dt         12 hour    # 12 hour time step
-tstop      21550 day   # Stop time after the given period (1822 = 5; 3650=10; 5475=15; 7300=20, 18250 = 50, 21550 = year 2050)
-toutstart  0 day      # Output start time
-toutinc    91 day    # Write output with this periodicity: 1yr run = 1 day; 5 year = 30; 20 year = 91 days
-toutfinc   365 day     # Write fisheries output with this periodicity
+tstop      10220 day   # Stop time after the given period (1822 = 5; 3650=10; 5475=15; 7300=20, 18250 = 50, 21550 = year 2050)
+toutstart  9855 day      # Output start time
+toutinc    1 day    # Write output with this periodicity: 1yr run = 1 day; 5 year = 30; 20 year = 91 days
+toutfinc   1 day     # Write fisheries output with this periodicity
 
-tsumout    365 day     # Write stock state summary with this periodicity; migration debug
+tsumout    1 day     # Write stock state summary with this periodicity; migration debug
 fishout    0          # Switch to turn fisheries output on = 1, off = 0
 flagreusefile 2        # Switch to show want to append output file no = 0, yes = 1, replace = 2
 flagannual_Mest 1      # Write out mortality per predator annually (1) or not (0) #

--- a/ShipScrubber/atlantis_scrubber.yaml
+++ b/ShipScrubber/atlantis_scrubber.yaml
@@ -21,7 +21,7 @@ parameters:
   # The run, forcing, physics, biology, and harvest parameters files are required for all runs,
   # and they must be identified by those exact keys.
   run: /ocean/$USER/Atlantis/SSAM_Runs/ShipScrubber/SS_run.prm
-  forcing: /ocean/$USER/Atlantis/SSAM_Runs/ShipScrubber/SS_forcing2019-2029.prm
+  forcing: /ocean/$USER/Atlantis/SSAM_Runs/ShipScrubber/SS_forcing2019.prm
   physics: /ocean/$USER/Atlantis/salish-sea-atlantis-model/SS_physics.prm
   biology: /ocean/$USER/Atlantis/salish-sea-atlantis-model/01SS_biology_linear_per_day.prm
   harvest: /ocean/$USER/Atlantis/salish-sea-atlantis-model/SS_harvest.prm

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,7 +1,7 @@
 run id: SS-Atlantis
 
 paths:
-  atlantis code: /ocean/$USER/Atlantis/atlantis-trunk/atlantis_v6655
+  atlantis code: /ocean/$USER/Atlantis/atlantis-trunk/atlantis_v6666
   atlantis executable name: atlantisMerged
   runs directory: /ocean/$USER/Atlantis/SSAM_Runs/
   atlantis command: $HOME/conda_envs/atlantis-cmd/bin/atlantis
@@ -21,10 +21,10 @@ fisheries: /ocean/$USER/Atlantis/salish-sea-atlantis-model/SS_fisheries.csv
 parameters:
   # The run, forcing, physics, biology, and harvest parameters files are required for all runs,
   # and they must be identified by those exact keys.
-  run: /ocean/$USER/Atlantis/SSAM_Runs/SS_run_contam.prm
+  run: /ocean/$USER/Atlantis/SSAM_Runs/SS_run_control.prm
   forcing: /ocean/$USER/Atlantis/SSAM_Runs/SS_forcing_contam_2020spill.prm
   physics: /ocean/$USER/Atlantis/salish-sea-atlantis-model/SS_physics.prm
-  biology: /ocean/$USER/Atlantis/salish-sea-atlantis-model/01SS_biology copy linear per day.prm
+  biology: /ocean/$USER/Atlantis/salish-sea-atlantis-model/01SS_biology_linear_per_day.prm
   harvest: /ocean/$USER/Atlantis/salish-sea-atlantis-model/SS_harvest.prm
 
 forcing:


### PR DESCRIPTION
1. Ran the same 2019 scrubber discharge scenario (1) run, but with higher resolution output by making only the following changes for both the scenario and the control

- starting the Atlantis output right before contaminant discharge
- changing the output resolution to 1 day
- ending the run after 1 year

2. At higher resolution, we could output results of the mortality calculation to test for realistic values (positive) to eliminate the possibility of a code bug for growth of some biological groups. Mortality values were output by adding the following fprint to lines 1187 and 1262 of atContaminants.c in Atlantis v6666.

`fprintf(bm->logFile,"Time: %e %s-%d contaminantSpMor: %e\n", bm->dayt, FunctGroupArray[species].groupCode, cohort, FunctGroupArray[species].contaminantSpMort[cohort]);
`

3. Nudged the spill date closer to the actual date by removing one year of zeros (1 file) prior to the spill.

4. Updated the oil spill from ships project with the correct run files.